### PR TITLE
Remove koan for deprecated map & set tuple features

### DIFF
--- a/src/test/scala/org/scalakoans/AboutMaps.scala
+++ b/src/test/scala/org/scalakoans/AboutMaps.scala
@@ -112,15 +112,6 @@ class AboutMaps extends KoanSuite  {
     aNewMap.size should be(__)
   }
 
-  koan("Map elements can be removed with a tuple") {
-    val myMap = Map("MI" -> "Michigan", "OH" -> "Ohio", "WI" -> "Wisconsin", "IA" -> "Iowa")
-    val aNewMap = myMap -- List("MI", "WI") // Notice: single '-' operator for tuples
-
-    aNewMap.contains("MI") should be(__)
-    aNewMap.contains("OH") should be(__)
-    aNewMap.size should be(__)
-  }
-
   koan("Attempted removal of nonexistent elements from a map is handled gracefully") {
     val myMap = Map("MI" -> "Michigan", "OH" -> "Ohio", "WI" -> "Wisconsin", "IA" -> "Iowa")
     val aNewMap = myMap - "MN"

--- a/src/test/scala/org/scalakoans/AboutMutableSets.scala
+++ b/src/test/scala/org/scalakoans/AboutMutableSets.scala
@@ -21,13 +21,6 @@ class AboutMutableSets extends KoanSuite  {
     mySet contains "Ohio" should be(__)
   }
 
-  koan("Mutable sets can have tuples of elements added") {
-    val mySet = mutable.Set("Michigan", "Wisconsin")
-    mySet += ("Iowa", "Ohio")
-    mySet contains "Ohio" should be(__)
-    mySet.size should be(__)
-  }
-
   koan("Mutable sets can have Lists of elements added") {
     val mySet = mutable.Set("Michigan", "Wisconsin")
     mySet ++= List("Iowa", "Ohio")

--- a/src/test/scala/org/scalakoans/AboutMutableSets.scala
+++ b/src/test/scala/org/scalakoans/AboutMutableSets.scala
@@ -21,16 +21,9 @@ class AboutMutableSets extends KoanSuite  {
     mySet contains "Ohio" should be(__)
   }
 
-  koan("Mutable sets can have tuples of elements removed") {
-    val mySet = mutable.Set("Michigan", "Ohio", "Wisconsin", "Iowa")
-    mySet --= List("Iowa", "Ohio")
-    mySet contains "Ohio" should be(__)
-    mySet.size should be(__)
-  }
-
   koan("Mutable sets can have tuples of elements added") {
     val mySet = mutable.Set("Michigan", "Wisconsin")
-    mySet ++= List("Iowa", "Ohio")
+    mySet += ("Iowa", "Ohio")
     mySet contains "Ohio" should be(__)
     mySet.size should be(__)
   }

--- a/src/test/scala/org/scalakoans/AboutSets.scala
+++ b/src/test/scala/org/scalakoans/AboutSets.scala
@@ -58,14 +58,6 @@ class AboutSets extends KoanSuite  {
     aNewSet.size should be(__)
   }
 
-  koan("Set elements can be removed with a tuple") {
-    val mySet = Set("Michigan", "Ohio", "Wisconsin", "Iowa")
-    val aNewSet = mySet.removedAll(Set("Michigan", "Ohio"))
-
-    aNewSet.contains("Michigan") should be(__)
-    aNewSet.contains("Wisconsin") should be(__)
-    aNewSet.size should be(__)
-  }
   koan("Attempted removal of nonexistent elements from a set is handled gracefully") {
     val mySet = Set("Michigan", "Ohio", "Wisconsin", "Iowa")
     val aNewSet = mySet - "Minnesota"
@@ -124,7 +116,5 @@ class AboutSets extends KoanSuite  {
 
     mySet1.equals(mySet2) should be(__)
   }
-
-
 
 }


### PR DESCRIPTION
Remove "Map/Set elements can be removed with a tuple" koan since this feature has been deprecated since 2.13.0.

It was previously updated to fix the compiler warning but inadvertently caused the koan to be identical to the "Map elements can be removed in multiple" koan right above it. 